### PR TITLE
Pull Request: Expression Prediction handling and minor fixes

### DIFF
--- a/perttf/model/pert_emb.py
+++ b/perttf/model/pert_emb.py
@@ -67,7 +67,7 @@ def load_pert_embedding_from_gears(gears_path, adata,
 
 
 
-def load_pert_embedding_to_model(o_model, model_weights):
+def load_pert_embedding_to_model(o_model, model_weights, requires_grad = True):
     """
     load pretrained perturbation embeddings to model
     Args:
@@ -82,6 +82,7 @@ def load_pert_embedding_to_model(o_model, model_weights):
     if model_weights_tensor.shape != o_model.pert_encoder.embedding.weight.shape:
         raise ValueError(f"model_weights_tensor.shape {model_weights_tensor.shape} does not equal to o_model.pert_encoder.embedding.weight.shape {o_model.pert_encoder.embedding.weight.shape}")
     o_model.pert_encoder.embedding.weight.data = model_weights_tensor # torch.tensor(gears_model_subset,dtype=torch.double)
+    o_model.pert_encoder.embedding.weight.requires_grad = requires_grad
     return o_model
 
 

--- a/perttf/model/train_data_gen.py
+++ b/perttf/model/train_data_gen.py
@@ -79,7 +79,8 @@ def add_pred_layer(adata: AnnData,
         ps_matrix=np.nan_to_num(ps_matrix,nan=0.0)
     else:
         ps_exist_c=["PS"]
-        ps_matrix= [0.0] * adata_p.shape[0] # a shape of 0
+        ps_matrix= [0.0] * adata_p.shape[0]# a shape of 0
+        ps_matrix = np.array(ps_matrix) # must be an np array
     #
     if next_cell_pred == "identity":
         perturbation_labels_next = perturbation_labels_0
@@ -116,7 +117,6 @@ def add_pred_layer(adata: AnnData,
 
     target_pert=[]
     target_cell_id=[]
-
     for this_cell in adata_p.obs.index.values:
         this_cell_type = adata_p.obs.loc[this_cell]['celltype']
         this_geno_type = adata_p.obs.loc[this_cell]['genotype']
@@ -134,10 +134,8 @@ def add_pred_layer(adata: AnnData,
     #(adata_p.layers[binned_layer_key].toarray() if issparse(adata_p.layers[binned_layer_key]) else adata_p.layers[binned_layer_key])
 
     input_layers=all_counts_0 # adata.layers[binned_layer_key] #.copy()
-
     target_cell_id_index=obsf.index.get_indexer(target_cell_id)
     target_layers=input_layers[target_cell_id_index]
-
     perturbation_labels_next = target_pert
     perturbation_labels_next = np.array(perturbation_labels_next)
     # return the ps matrix next
@@ -342,7 +340,7 @@ def produce_training_datasets(adata_input, config,
 
         ps_0 = np.array(ps_0)
         ps_next_0 = np.array(ps_next_0)
-        
+        # TODO: need to make sure matrices are either not scipy sparse or implement sparse concatenations below
         if adata is None:
             adata = adata_0 #.copy()
             next_counts = next_counts_0

--- a/perttf/model/train_function.py
+++ b/perttf/model/train_function.py
@@ -475,6 +475,7 @@ def eval_testdata(
     epoch = 0,
     eval_key = "", # titles for evaluation
     make_plots = True,
+    predict_expr = False
 ) -> Optional[Dict]:
     """evaluate the model on test dataset of adata_t"""
     model.eval()
@@ -590,7 +591,7 @@ def eval_testdata(
                 pert_labels_next = torch.from_numpy(perturbation_indexes_next).long() if next_cell_prediction else None,
                 time_step=0,
                 return_np=True,
-                predict_expr = True
+                predict_expr = predict_expr
             )
 
         cell_embeddings = cell_embeddings / np.linalg.norm(
@@ -604,10 +605,12 @@ def eval_testdata(
         adata_t.obsm["X_scGPT_next"] = cell_embeddings_next
         #adata_t.obsm["X_pert_pred"] = pert_preds
         if config.ps_weight >0:
-          adata_t.obsm["ps_pred"] = ps_preds
-        if 'mvc_next_expr' in expr_dict:
-            adata_t.obsm["X_scGPT_next_expr"] = expr_dict['mvc_next_expr'][0]
-            adata_t.obsm["X_scGPT_next_expr_zero"] =  expr_dict['mvc_next_expr'][1]
+            adata_t.obsm["ps_pred"] = ps_preds
+        for k in expr_dict:
+
+            adata_t.obsm[k] = expr_dict[k][0]
+            if len(expr_dict[k]) > 1:
+                adata_t.obsm[k+'_zero'] =  expr_dict[k][1]
         # require: genotype_to_index
 
         # Assuming ret_adata.obsm['X_pert_pred'] is a numpy array or can be converted to one

--- a/perttf/model/train_function.py
+++ b/perttf/model/train_function.py
@@ -582,7 +582,7 @@ def eval_testdata(
             #    time_step=0,
             #    return_np=True,
             #)
-            cell_embeddings, cell_embeddings_next, pert_preds, cls_preds, ps_preds = model.encode_batch_with_perturb(all_gene_ids,all_values.float(),
+            cell_embeddings, cell_embeddings_next, pert_preds, cls_preds, ps_preds, expr_dict = model.encode_batch_with_perturb(all_gene_ids,all_values.float(),
                 src_key_padding_mask=src_key_padding_mask,
                 batch_size=config.batch_size,
                 batch_labels=torch.from_numpy(batch_ids).long() if config.use_batch_label else None, # if config.DSBN else None,
@@ -590,6 +590,7 @@ def eval_testdata(
                 pert_labels_next = torch.from_numpy(perturbation_indexes_next).long() if next_cell_prediction else None,
                 time_step=0,
                 return_np=True,
+                predict_expr = True
             )
 
         cell_embeddings = cell_embeddings / np.linalg.norm(
@@ -604,7 +605,9 @@ def eval_testdata(
         #adata_t.obsm["X_pert_pred"] = pert_preds
         if config.ps_weight >0:
           adata_t.obsm["ps_pred"] = ps_preds
-
+        if 'mvc_next_expr' in expr_dict:
+            adata_t.obsm["X_scGPT_next_expr"] = expr_dict['mvc_next_expr'][0]
+            adata_t.obsm["X_scGPT_next_expr_zero"] =  expr_dict['mvc_next_expr'][1]
         # require: genotype_to_index
 
         # Assuming ret_adata.obsm['X_pert_pred'] is a numpy array or can be converted to one

--- a/perttf/model/train_function.py
+++ b/perttf/model/train_function.py
@@ -52,7 +52,6 @@ def train(model: nn.Module,
 
     if device is None:
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
     model.train()
     total_loss, total_mse, total_gepc = 0.0, 0.0, 0.0
     total_mse_next, total_gepc_next = 0.0, 0.0
@@ -368,7 +367,7 @@ def evaluate(model: nn.Module,
     if device is None:
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-
+    
     model.eval()
     total_loss = 0.0
     total_loss_next = 0.0
@@ -894,6 +893,7 @@ def wrapper_train(model, config, data_gen,
                 optimizer_dict,
                 epoch = epoch,
                 logger = logger,
+                device = device
             )
         val_loss, val_loss_next, val_mre, val_mre_next, val_dab, val_cls, val_pert, val_ps = evaluate(
             model,
@@ -901,6 +901,7 @@ def wrapper_train(model, config, data_gen,
             config=config,
             vocab = vocab,
             epoch = epoch,
+            device = device
         )
         elapsed = time.time() - epoch_start_time
         if logger is not None:

--- a/perttf/utils/logger.py
+++ b/perttf/utils/logger.py
@@ -1,0 +1,17 @@
+import logging
+import sys
+def create_logger(id=0):
+
+    logger = logging.getLogger(f"pertTF_worker_{id}")
+# check if logger has been initialized
+    if not logger.hasHandlers() or len(logger.handlers) == 0:
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setLevel(logging.INFO)
+        formatter = logging.Formatter(
+        "%(name)s - %(levelname)s - %(message)s", datefmt="%H:%M:%S"
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+    return logger

--- a/perttf/utils/misc.py
+++ b/perttf/utils/misc.py
@@ -1,0 +1,75 @@
+import numpy as np
+from typing import Literal
+
+# Courtesy of Gemini AI, unbin predicted expr values if they were binned prior to scGPT
+def unbin_matrix(
+    binned_matrix: np.ndarray,
+    bin_edges_matrix: np.ndarray,
+    method: Literal["mean", "median"] = "mean",
+) -> np.ndarray:
+    """
+    Converts a 2D matrix of binned indices back to continuous values.
+
+    This function processes a matrix where each row represents a cell with
+    integer bin indices. It uses a corresponding matrix of bin edges, where
+    each row defines the bin boundaries for the respective cell.
+
+    Args:
+        binned_matrix (np.ndarray):
+            A 2D numpy array of integer bin indices (cells x genes).
+        bin_edges_matrix (np.ndarray):
+            A 2D numpy array of bin edge values. Each row i corresponds to
+            the bin edges for row i in binned_matrix. Note that rows can
+            have different numbers of bins and therefore different lengths.
+            This is handled by providing it as a numpy array of objects
+            (dtype=object).
+        method (Literal["mean", "median"], optional):
+            The method to estimate the unbinned value. For a uniform
+            distribution within a bin, the mean and median are the same.
+            Defaults to "mean".
+
+    Returns:
+        np.ndarray:
+            A 2D numpy array of the same shape as `binned_matrix` with the
+            approximated continuous float values.
+    """
+    # --- Input Validation ---
+    if binned_matrix.ndim != 2:
+        raise ValueError("Input `binned_matrix` must be a 2D numpy array.")
+    # For bin_edges_matrix, we expect an array of arrays, so we check the first dimension
+    if binned_matrix.shape[0] != len(bin_edges_matrix):
+        raise ValueError(
+            "The number of rows in `binned_matrix` must match the number of "
+            "rows in `bin_edges_matrix`."
+        )
+
+    # --- Initialization ---
+    unbinned_matrix = np.zeros_like(binned_matrix, dtype=float)
+
+    # --- Processing ---
+    for i in range(binned_matrix.shape[0]):
+        binned_row = binned_matrix[i]
+        bin_edges_row = bin_edges_matrix[i]
+        
+        # Get unique non-zero bin indices present in the current row
+        unique_bins = np.unique(binned_row[binned_row > 0])
+
+        for bin_idx in unique_bins:
+            if bin_idx >= len(bin_edges_row):
+                raise IndexError(
+                    f"In row {i}, bin index {bin_idx} is out of bounds for the "
+                    f"provided bin_edges array of length {len(bin_edges_row)}."
+                )
+
+            lower_bound = bin_edges_row[bin_idx - 1]
+            upper_bound = bin_edges_row[bin_idx]
+
+            if method in ["mean", "median"]:
+                rep_value = (lower_bound + upper_bound) / 2.0
+            else:
+                raise ValueError("Method must be either 'mean' or 'median'.")
+            
+            # Assign the representative value to all matching locations in the row
+            unbinned_matrix[i, binned_row == bin_idx] = rep_value
+
+    return unbinned_matrix


### PR DESCRIPTION

## Changes & New Functionalities

### 1. Expression Prediction and Output Handling
- All predicted expressions are now output in `adata.obsm`, with an option (`predict_expr`) for controlling prediction during `eval_testdata`.
- Added handling for predicted next cell expression in evaluation, providing more comprehensive output.
- Introduced an option for returning multiple predicted expressions in `encode_batch_with_perturb`:
    - `model.decode(cell_emb, ...)`
    - `model.mvc_decode(cell_emb, ...)`
    - `model.mvc_decode(cell_emb_next, ...)`
- Added a function in `utils` for converting binned values back to continuous values (not currently used, but available for future needs).

### 2. Model & Training Infrastructure
- Added option to fix gradients for gears gene embeddings, providing additional training control and experimentation.
- Updated `logger` to handle multiprocessing workers, enabling  compatibility with parallelized data loading and training.
- `device` arguments are now passed to both `train` and `evaluate` functions, allowing explicit GPU assignment.

## Minor Fixes & Code Maintenance

- Ensured `ps_matrix` is always a NumPy array, with a TODO noted for handling concatenation of sparse matrices.
- Various bug fixes addressing prediction output and logging.



