### PR TITLE
# Fix for tokenize_and_pad_batch to align train_data and next_train_data

### DIFF
--- a/perttf/model/pertTF.py
+++ b/perttf/model/pertTF.py
@@ -127,6 +127,7 @@ class PertExpEncoder(nn.Module):
     ):
         super().__init__()
         d_in = d_model * 2 
+        #d_in = d_model
         self.fc = nn.Sequential(
             nn.Linear(d_in, d_model),
             nn.Sigmoid(),#nn.ReLU(),#nn.LeakyReLU(),
@@ -354,6 +355,7 @@ class PerturbationTFModel(TransformerModel):
                 ],
                 dim=1,
             )
+            #tf_concat = cell_emb_orig + pert_emb_next
             cell_emb_next=self.pert_exp_encoder(tf_concat)
         else:
             cell_emb_next=cell_emb_orig
@@ -550,6 +552,7 @@ class PerturbationTFModel(TransformerModel):
                 tf_concat=torch.cat(
                     [cell_emb,pert_emb_next], dim=1,
                 )
+                #tf_concat = cell_emb + pert_emb_next
                 cell_emb_next=self.pert_exp_encoder(tf_concat)
                 if output_to_cpu:
                     cell_emb_next_cpu = cell_emb_next.cpu()

--- a/perttf/model/train_data_gen.py
+++ b/perttf/model/train_data_gen.py
@@ -16,7 +16,7 @@ from torchtext._torchtext import (
 )
 
 import scgpt as scg
-from scgpt.tokenizer import tokenize_and_pad_batch, random_mask_value
+from utils.custom_tokenizer import tokenize_and_pad_batch, random_mask_value
 from scgpt import SubsetsBatchSampler
 
 def add_pred_layer(adata: AnnData, 
@@ -472,7 +472,7 @@ def produce_training_datasets(adata_input, config,
 
     # construct tokenized data
     print('tokenize data...')
-    tokenized_train = tokenize_and_pad_batch(
+    tokenized_train, gene_idx_list_train= tokenize_and_pad_batch(
         train_data,
         gene_ids,
         max_len=config.max_seq_len,
@@ -482,7 +482,7 @@ def produce_training_datasets(adata_input, config,
         append_cls=True,  # append <cls> token at the beginning
         include_zero_gene=True,
     )
-    tokenized_valid = tokenize_and_pad_batch(
+    tokenized_valid, gene_idx_list_valid = tokenize_and_pad_batch(
         valid_data,
         gene_ids,
         max_len=config.max_seq_len,
@@ -493,7 +493,7 @@ def produce_training_datasets(adata_input, config,
         include_zero_gene=True,
     )
 
-    tokenized_train_next = tokenize_and_pad_batch(
+    tokenized_train_next, _ = tokenize_and_pad_batch(
         train_data_next,
         gene_ids,
         max_len=config.max_seq_len,
@@ -502,8 +502,9 @@ def produce_training_datasets(adata_input, config,
         pad_value=config.pad_value,
         append_cls=True,  # append <cls> token at the beginning
         include_zero_gene=True,
+         sample_indices= gene_idx_list_train
     )
-    tokenized_valid_next = tokenize_and_pad_batch(
+    tokenized_valid_next, _ = tokenize_and_pad_batch(
         valid_data_next,
         gene_ids,
         max_len=config.max_seq_len,
@@ -511,7 +512,9 @@ def produce_training_datasets(adata_input, config,
         pad_token=config.pad_token,
         pad_value=config.pad_value,
         append_cls=True,
-        include_zero_gene=True,
+        include_zero_gene=True, 
+        sample_indices= gene_idx_list_valid
+
     )
     if logger is not None:
         logger.info(

--- a/perttf/model/train_function.py
+++ b/perttf/model/train_function.py
@@ -24,7 +24,7 @@ from scgpt.loss import (
     masked_relative_error,
     criterion_neg_log_bernoulli,
 )
-from scgpt.tokenizer import tokenize_and_pad_batch, random_mask_value
+from utils.custom_tokenizer import tokenize_and_pad_batch, random_mask_value
 from scgpt.model import TransformerModel, AdversarialDiscriminator
 
 import matplotlib.pyplot as plt
@@ -547,7 +547,7 @@ def eval_testdata(
     if "cls" in include_types:
         if logger is not None:
             logger.info("Evaluating cls cell embeddings")
-        tokenized_all = tokenize_and_pad_batch(
+        tokenized_all, gene_idx_list= tokenize_and_pad_batch(
             all_counts,
             gene_ids,
             max_len=config.max_seq_len,
@@ -562,7 +562,7 @@ def eval_testdata(
         all_gene_ids, all_values = tokenized_all["genes"], tokenized_all["values"]
 
         if next_layer_key in adata_t.layers:
-            tokenized_all_next = tokenize_and_pad_batch(
+            tokenized_all_next, _ = tokenize_and_pad_batch(
                 all_counts_next,
                 gene_ids,
                 max_len=config.max_seq_len,
@@ -571,6 +571,7 @@ def eval_testdata(
                 pad_value=config.pad_value,
                 append_cls=True,  # append <cls> token at the beginning
                 include_zero_gene=True,
+                sample_indices=gene_idx_list
             )
             all_gene_ids_next, all_values_next = tokenized_all_next["genes"], tokenized_all_next["values"]
 

--- a/perttf/utils/custom_tokenizer.py
+++ b/perttf/utils/custom_tokenizer.py
@@ -15,7 +15,6 @@ from torchtext.vocab import Vocab
 # from transformers.tokenization_utils import PreTrainedTokenizer
 # from transformers import AutoTokenizer, BertTokenizer
 
-from .. import logger
 
 # This function remains unchanged
 def tokenize_batch(

--- a/perttf/utils/custom_tokenizer.py
+++ b/perttf/utils/custom_tokenizer.py
@@ -1,0 +1,246 @@
+# This is modified from code from scGPT's gene_tokenizer to accomodate tokenizing next_cell pert target data
+import json
+import pickle
+from pathlib import Path
+from collections import Counter, OrderedDict
+from typing import Dict, Iterable, List, Optional, Tuple, Union
+from typing_extensions import Self
+
+import numpy as np
+import pandas as pd
+import torch
+import torchtext.vocab as torch_vocab
+from torchtext.vocab import Vocab
+
+# from transformers.tokenization_utils import PreTrainedTokenizer
+# from transformers import AutoTokenizer, BertTokenizer
+
+from .. import logger
+
+
+
+def tokenize_batch(
+    data: np.ndarray,
+    gene_ids: np.ndarray,
+    return_pt: bool = True,
+    append_cls: bool = True,
+    include_zero_gene: bool = False,
+    cls_id: int = "<cls>",
+    mod_type: np.ndarray = None,
+    cls_id_mod_type: int = None,
+) -> List[Tuple[Union[torch.Tensor, np.ndarray]]]:
+    """
+    Tokenize a batch of data. Returns a list of tuple (gene_id, count).
+
+    Args:
+        data (array-like): A batch of data, with shape (batch_size, n_features).
+            n_features equals the number of all genes.
+        gene_ids (array-like): A batch of gene ids, with shape (n_features,).
+        return_pt (bool): Whether to return torch tensors of gene_ids and counts,
+            default to True.
+
+    Returns:
+        list: A list of tuple (gene_id, count) of non zero gene expressions.
+    """
+    if data.shape[1] != len(gene_ids):
+        raise ValueError(
+            f"Number of features in data ({data.shape[1]}) does not match "
+            f"number of gene_ids ({len(gene_ids)})."
+        )
+    if mod_type is not None and data.shape[1] != len(mod_type):
+        raise ValueError(
+            f"Number of features in data ({data.shape[1]}) does not match "
+            f"number of mod_type ({len(mod_type)})."
+        )
+
+    tokenized_data = []
+    for i in range(len(data)):
+        row = data[i]
+        mod_types = None
+        if include_zero_gene:
+            values = row
+            genes = gene_ids
+            if mod_type is not None:
+                mod_types = mod_type
+        else:
+            idx = np.nonzero(row)[0]
+            values = row[idx]
+            genes = gene_ids[idx]
+            if mod_type is not None:
+                mod_types = mod_type[idx]
+        if append_cls:
+            genes = np.insert(genes, 0, cls_id)
+            values = np.insert(values, 0, 0)
+            if mod_type is not None:
+                mod_types = np.insert(mod_types, 0, cls_id_mod_type)
+        if return_pt:
+            genes = torch.from_numpy(genes).long()
+            values = torch.from_numpy(values).float()
+            if mod_type is not None:
+                mod_types = torch.from_numpy(mod_types).long()
+        tokenized_data.append((genes, values, mod_types))
+    return tokenized_data
+
+
+def pad_batch(
+    batch: List[Tuple],
+    max_len: int,
+    vocab: Vocab,
+    pad_token: str = "<pad>",
+    pad_value: int = 0,
+    cls_appended: bool = True,
+    vocab_mod: Vocab = None,
+) -> Dict[str, torch.Tensor]:
+    """
+    Pad a batch of data. Returns a list of Dict[gene_id, count].
+
+    Args:
+        batch (list): A list of tuple (gene_id, count).
+        max_len (int): The maximum length of the batch.
+        vocab (Vocab): The vocabulary containing the pad token.
+        pad_token (str): The token to pad with.
+
+    Returns:
+        Dict[str, torch.Tensor]: A dictionary of gene_id and count.
+    """
+    max_ori_len = max(len(batch[i][0]) for i in range(len(batch)))
+    max_len = min(max_ori_len, max_len)
+
+    pad_id = vocab[pad_token]
+    if vocab_mod is not None:
+        mod_pad_id = vocab_mod[pad_token]
+    gene_ids_list = []
+    values_list = []
+    mod_types_list = []
+
+    for i in range(len(batch)):
+        gene_ids, values, mod_types = batch[i]
+
+        if len(gene_ids) > max_len:
+            # sample max_len genes
+            if not cls_appended:
+                idx = np.random.choice(len(gene_ids), max_len, replace=False)
+            else:
+                idx = np.random.choice(len(gene_ids) - 1, max_len - 1, replace=False)
+                idx = idx + 1
+                idx = np.insert(idx, 0, 0)
+            gene_ids = gene_ids[idx]
+            values = values[idx]
+            if mod_types is not None:
+                mod_types = mod_types[idx]
+        if len(gene_ids) < max_len:
+            gene_ids = torch.cat(
+                [
+                    gene_ids,
+                    torch.full(
+                        (max_len - len(gene_ids),), pad_id, dtype=gene_ids.dtype
+                    ),
+                ]
+            )
+            values = torch.cat(
+                [
+                    values,
+                    torch.full((max_len - len(values),), pad_value, dtype=values.dtype),
+                ]
+            )
+            if mod_types is not None:
+                mod_types = torch.cat(
+                    [
+                        mod_types,
+                        torch.full(
+                            (max_len - len(mod_types),),
+                            mod_pad_id,
+                            dtype=mod_types.dtype,
+                        ),
+                    ]
+                )
+
+        gene_ids_list.append(gene_ids)
+        values_list.append(values)
+        if mod_types is not None:
+            mod_types_list.append(mod_types)
+
+    batch_padded = {
+        "genes": torch.stack(gene_ids_list, dim=0),
+        "values": torch.stack(values_list, dim=0),
+    }
+    if mod_types is not None:
+        batch_padded["mod_types"] = torch.stack(mod_types_list, dim=0)
+    return batch_padded
+
+# changed to allow gene ids to be set for a batch of data
+def tokenize_and_pad_batch(
+    data: np.ndarray,
+    gene_ids: np.ndarray,
+    max_len: int,
+    vocab: Vocab,
+    pad_token: str,
+    pad_value: int,
+    append_cls: bool = True,
+    include_zero_gene: bool = False,
+    cls_token: str = "<cls>",
+    return_pt: bool = True,
+    mod_type: np.ndarray = None,
+    vocab_mod: Vocab = None,
+) -> Dict[str, torch.Tensor]:
+    """
+    Tokenize and pad a batch of data. Returns a list of tuple (gene_id, count).
+    """
+    cls_id = vocab[cls_token]
+    if mod_type is not None:
+        cls_id_mod_type = vocab_mod[cls_token]
+    tokenized_data = tokenize_batch(
+        data,
+        gene_ids,
+        return_pt=return_pt,
+        append_cls=append_cls,
+        include_zero_gene=include_zero_gene,
+        cls_id=cls_id,
+        mod_type=mod_type,
+        cls_id_mod_type=cls_id_mod_type if mod_type is not None else None,
+    )
+
+    batch_padded = pad_batch(
+        tokenized_data,
+        max_len,
+        vocab,
+        pad_token,
+        pad_value,
+        cls_appended=append_cls,
+        vocab_mod=vocab_mod,
+    )
+    return batch_padded
+
+# Currently still the same as scGPT, but maybe customize in the future
+def random_mask_value(
+    values: Union[torch.Tensor, np.ndarray],
+    mask_ratio: float = 0.15,
+    mask_value: int = -1,
+    pad_value: int = 0,
+) -> torch.Tensor:
+    """
+    Randomly mask a batch of data.
+
+    Args:
+        values (array-like):
+            A batch of tokenized data, with shape (batch_size, n_features).
+        mask_ratio (float): The ratio of genes to mask, default to 0.15.
+        mask_value (int): The value to mask with, default to -1.
+        pad_value (int): The value of padding in the values, will be kept unchanged.
+
+    Returns:
+        torch.Tensor: A tensor of masked data.
+    """
+    if isinstance(values, torch.Tensor):
+        # it is crutial to clone the tensor, otherwise it changes the original tensor
+        values = values.clone().detach().numpy()
+    else:
+        values = values.copy()
+
+    for i in range(len(values)):
+        row = values[i]
+        non_padding_idx = np.nonzero(row - pad_value)[0]
+        n_mask = int(len(non_padding_idx) * mask_ratio)
+        mask_idx = np.random.choice(non_padding_idx, n_mask, replace=False)
+        row[mask_idx] = mask_value
+    return torch.from_numpy(values).float()


### PR DESCRIPTION
## Summary
This pull request introduces changes to address issues with the `tokenize_and_pad_batch` functionality. The main fix involves replacing the original tokenizer with a custom tokenizer to resolve issues that occur when gene tokens used in training are sampled seperately for train_data and next_train_data, causing misaligned gene ids that fails to train perturbed expression

## Changes
1. **Custom Tokenizer**:
   - Added a new file `custom_tokenizer.py` that provides a tailored mechanism for tokenizing and padding batches.
   - Enhanced functionality to handle `sample_indices` for selective sampling.

2. **Integration Updates**:
   - Updated `train_data_gen.py` and `train_function.py` to use the new custom tokenizer (`utils.custom_tokenizer`) instead of the original `scgpt.tokenizer`.
   - Added support for extra parameters, such as `sample_indices`, in function calls to `tokenize_and_pad_batch`.
   - Minor updates to tensor operations in `pertTF.py`.