### PR TITLE
Refactor loss train eval

### DIFF
--- a/perttf/model/train_function.py
+++ b/perttf/model/train_function.py
@@ -745,7 +745,7 @@ def eval_testdata(
     batch_ids = np.array(batch_ids)
 
     if mvc_full_expr: # if we want to get full expression from mvc decoder
-        max_seq_len = config.max_seq_len if config.get('simple_sampling', True) else 10000
+        max_seq_len = config.max_seq_len if config.get('sampling_mode', 'simple') else 10000
         cls_gene_ids = np.insert(gene_ids, 0, vocab[config.cls_token]) # default should always be to insert a cls token at the front
         full_gene_ids = torch.stack([torch.from_numpy(cls_gene_ids).long() for i in range(adata_t.shape[0])], dim = 0)
     else:
@@ -753,6 +753,13 @@ def eval_testdata(
         full_gene_ids = None
     # Evaluate cls cell embeddings
     if "cls" in include_types:
+        sampling_mode = config.get('sampling_mode', 'simple')
+        hvg_inds = None
+        if sampling_mode == 'hvg':
+            hvg_col = config.get('hvg_col', 'highly_variable')
+            assert hvg_col in adata_t.var.keys(), 'adata must have calculated HVGs or adata.var must have hvg_col'
+            hvg_inds = (np.where(adata_t.var[hvg_col])[0], np.where(~adata_t.var[hvg_col])[0])
+            max_seq_len = max(adata_t.var[hvg_col].sum()+config.get('non_hvg_size', 1000), max_seq_len)
         if logger is not None:
             logger.info("Evaluating cls cell embeddings")
         tokenized_all, gene_idx_list= tokenize_and_pad_batch(
@@ -764,9 +771,11 @@ def eval_testdata(
             pad_value=config.pad_value,
             append_cls=True,  # append <cls> token at the beginning
             include_zero_gene=True,
-            simple_sampling = config.get('simple_sampling', True),
+            sampling_mode = config.get('sampling_mode', 'simple'),
             nonzero_prop = config.get('nonzero_prop', 0.7),
-            fix_nonzero_prop =  config.get('fix_nonzero_prop', False)
+            fix_nonzero_prop =  config.get('fix_nonzero_prop', False),
+            hvg_inds = hvg_inds, 
+            non_hvg_size= config.get('non_hvg_size', 1000)
         )
 
 
@@ -791,9 +800,11 @@ def eval_testdata(
                 append_cls=True,  # append <cls> token at the beginning
                 include_zero_gene=True,
                 sample_indices=gene_idx_list,
-                simple_sampling = config.get('simple_sampling', True),
+                sampling_mode = config.get('sampling_mode', 'simple'),
                 nonzero_prop = config.get('nonzero_prop', 0.7),
-                fix_nonzero_prop =  config.get('fix_nonzero_prop', False)
+                fix_nonzero_prop =  config.get('fix_nonzero_prop', False),
+                hvg_inds = hvg_inds, 
+                non_hvg_size= config.get('non_hvg_size', 1000)
             )
             all_gene_ids_next, all_values_next = tokenized_all_next["genes"], tokenized_all_next["values"]
         

--- a/perttf/model/train_function.py
+++ b/perttf/model/train_function.py
@@ -15,6 +15,9 @@ from torch.utils.data import Dataset, DataLoader
 from anndata import AnnData
 import scanpy as sc
 import multiprocessing
+from concurrent.futures import ProcessPoolExecutor
+from types import SimpleNamespace
+#multiprocessing.set_start_method('spawn', force=True)
 import wandb
 from scipy.sparse import issparse
 
@@ -31,6 +34,7 @@ from perttf.model.train_data_gen import prepare_data, prepare_dataloader
 from perttf.utils.set_optimizer import create_optimizer_dict
 from perttf.custom_loss import cce_loss, criterion_neg_log_bernoulli, masked_mse_loss
 from perttf.utils.plot import process_and_log_umaps
+from perttf.utils.misc import init_plot_worker
 
 
 # function not used currently

--- a/perttf/model/train_function.py
+++ b/perttf/model/train_function.py
@@ -909,16 +909,31 @@ def wrapper_train(model, config, data_gen,
     # later, use the following to load json file
     #config_data = json.load(open(save_dir / 'config.json', 'r'))
     train_loader, valid_loader = data_gen['train_loader'], data_gen['valid_loader']
+    executor = ProcessPoolExecutor(
+        max_workers=4,
+        initializer=init_plot_worker,
+        mp_context=multiprocessing.get_context('forkserver') 
+        )
     evaltest_processes = []
 
     for epoch in range(1, config.epochs + 1):
         epoch_start_time = time.time()
         remaining_processes = []
         for p in evaltest_processes:
-            if p.is_alive():
-                remaining_processes.append(p)
+            if p.done():
+                try:
+                    result = p.result()
+                    metrics_to_log = result['metrics']
+                    for key, img_path in result['images'].items():
+                        metrics_to_log[key]= wandb.Image(img_path)  
+                    if metrics_to_log:
+                        wandb.log(metrics_to_log)
+                    logger.info(f'Finished {result["eval_dict_key"]} UMAP for epoch {result["epoch"]}')
+                except Exception as e:
+                    logger.warning(f'UMAP process failed for epoch {result["epoch"]} due to: {e}')
             else:
-                p.join()  # Joins the process to release resources
+                remaining_processes.append(p)
+         # Joins the process to release resources
         evaltest_processes = remaining_processes
         logger.info(f"Active UMAP processes: {len( evaltest_processes)}")
 
@@ -995,15 +1010,16 @@ def wrapper_train(model, config, data_gen,
                 
                 # Pass data_gen['ps_names'] if it exists, otherwise None
                 ps_names = data_gen.get('ps_names', None)
-                
-                p = multiprocessing.Process(
-                    target=process_and_log_umaps,
-                    args=(adata_with_embeddings, config, epoch, eval_dict_key, save_dir2, ps_names)
+                #p = multiprocessing.Process(
+                 #   target=process_and_log_umaps,
+                  #  args=(adata_with_embeddings, config, epoch, eval_dict_key, save_dir2, ps_names)
+                #)
+                #p.start()           
+                p = executor.submit(
+                    process_and_log_umaps,
+                    adata_with_embeddings, SimpleNamespace(**config) , epoch, eval_dict_key, save_dir2, ps_names
                 )
-                p.start()
                 evaltest_processes.append(p)
-
-        
 
             #metrics_to_log["test/best_model_epoch"] = best_model_epoch
             wandb.log({"test/best_model_epoch":best_model_epoch})

--- a/perttf/model/train_function.py
+++ b/perttf/model/train_function.py
@@ -997,8 +997,8 @@ def wrapper_train(model, config, data_gen,
                 logger.info(f"Best model with score {best_val_loss:5.4f}")
 
         #if epoch % config.save_eval_interval == 0 or epoch == config.epochs:
-        expression_epoch = config.get('eval_expr_interval', 0)
-        predict_expr_tmp = True if expression_epoch and epoch % expression_epoch == 0 else False
+        eval_expr_interval = config.get('eval_expr_interval', 0)
+        predict_expr_tmp = True if eval_expr_interval and epoch % eval_expr_interval == 0 and config.get('next_cell_pred_type') == 'pert' else False
         if epoch % 2 == 1:
             logger.info(f"Saving model to {save_dir}")
             torch.save(best_model.state_dict(), save_dir / "best_model.pt")

--- a/perttf/utils/custom_tokenizer.py
+++ b/perttf/utils/custom_tokenizer.py
@@ -103,17 +103,25 @@ class SimpleVocab:
         self.stoi[token] = len(self.itos)
 
 # Smarter sampling function to get more non-zero expression for each cell during sentence generation
-def weighted_sample(val, max_size, rng = default_rng(), simple = True, non_zero_proportion = 0.7, fixed_ratio = False):
-    if simple: # no weighted sampling
-        return rng.choice( len(val),size = max_size, replace = False)
-    nzero = np.where(val!=0)[0]
-    zero = np.where(val==0)[0]
-    non_zero_size = min(round(max_size*non_zero_proportion), len(nzero))
-    zero_size = max_size - non_zero_size if not fixed_ratio else min(max_size - non_zero_size, round(non_zero_size*(1-non_zero_proportion)/non_zero_proportion))
-    nz_inds= np.random.choice(len(nzero),size = non_zero_size, replace = False)
-    z_inds= np.random.choice(len(zero),size = zero_size, replace = False)
-    return np.concatenate([nzero[nz_inds], zero[z_inds]])
-
+def weighted_sample(val, max_size, rng = default_rng(), mode = 'simple', non_zero_proportion = 0.7, fixed_ratio = False, hvg_inds = None, non_hvg_size = 1000):
+    if mode == 'hvg':
+        assert hvg_inds is not None, 'hvg indices not given to sampling'
+        # hvg_ids is a tuple, first element is hvg indices, second element is non-hvg_indices
+        if non_hvg_size > 0:
+            non_hvgs= rng.choice(len(hvg_inds[1]), size = non_hvg_size, replace = False)
+            return np.concatenate([hvg_inds[0], hvg_inds[1][non_hvgs]])
+        else:
+            return hvg_inds[0]
+    elif mode == 'expressed':
+        nzero = np.where(val!=0)[0]
+        zero = np.where(val==0)[0]
+        non_zero_size = min(round(max_size*non_zero_proportion), len(nzero))
+        zero_size = max_size - non_zero_size if not fixed_ratio else min(max_size - non_zero_size, round(non_zero_size*(1-non_zero_proportion)/non_zero_proportion))
+        nz_inds= rng.choice(len(nzero),size = non_zero_size, replace = False)
+        z_inds= rng.choice(len(zero),size = zero_size, replace = False)
+        return np.concatenate([nzero[nz_inds], zero[z_inds]])
+    else:
+        return rng.choice(len(val),size = max_size, replace = False)
 
 # This function remains unchanged
 def tokenize_batch(
@@ -191,9 +199,11 @@ def pad_batch(
     vocab_mod: SimpleVocab = None,
     sample_indices: List[np.ndarray] = None,
     rng: default_rng = None,
-    simple_sampling = True,
+    sampling_mode: str = 'simple',
     nonzero_prop = 0.7,
     fix_nonzero_prop = False,
+    hvg_inds = None,
+    non_hvg_size = 0
 ) -> Tuple[Dict[str, torch.Tensor], List[np.ndarray]]:
     """
     Pad a batch of data.
@@ -237,10 +247,14 @@ def pad_batch(
             # Otherwise, perform random sampling
             else:
                 if not cls_appended:
-                    idx = weighted_sample(values, max_len, rng=rng, simple = simple_sampling, non_zero_proportion=nonzero_prop, fixed_ratio=fix_nonzero_prop)
+                    idx = weighted_sample(values, max_len, rng=rng, mode = sampling_mode, 
+                                            non_zero_proportion=nonzero_prop, fixed_ratio=fix_nonzero_prop, 
+                                            hvg_inds = hvg_inds, non_hvg_size = non_hvg_size)
                 else:
                     # sample from non-CLS tokens and add CLS token back
-                    idx = weighted_sample(values[1:], max_len - 1, rng=rng, simple = simple_sampling, non_zero_proportion=nonzero_prop, fixed_ratio=fix_nonzero_prop)
+                    idx = weighted_sample(values[1:], max_len - 1, rng=rng, mode = sampling_mode, 
+                                           non_zero_proportion=nonzero_prop, fixed_ratio=fix_nonzero_prop, 
+                                           hvg_inds = hvg_inds, non_hvg_size = non_hvg_size)
                     idx = idx + 1
                     idx = np.insert(idx, 0, 0)
             
@@ -315,9 +329,11 @@ def tokenize_and_pad_batch(
     mod_type: np.ndarray = None,
     vocab_mod: SimpleVocab = None,
     sample_indices: List[np.ndarray] = None,
-    simple_sampling: bool = True,
+    sampling_mode: str = 'simple',
     nonzero_prop: float = 0.7,
-    fix_nonzero_prop: bool = False
+    fix_nonzero_prop: bool = False,
+    hvg_inds = None,
+    non_hvg_size = 1000
 ) -> Tuple[Dict[str, torch.Tensor], List[np.ndarray]]:
     """
     Tokenize and pad a batch of data.
@@ -333,6 +349,8 @@ def tokenize_and_pad_batch(
             - The dictionary of padded data ('genes', 'values').
             - A list of the indices used for each sample.
     """
+    if hvg_inds is not None:
+        assert len(hvg_inds[0])+len(hvg_inds[1]) == len(gene_ids)
     cls_id = vocab[cls_token]
     cls_id_mod_type = None
     if mod_type is not None:
@@ -359,9 +377,11 @@ def tokenize_and_pad_batch(
         cls_appended=append_cls,
         vocab_mod=vocab_mod,
         sample_indices=sample_indices, # Pass the indices here
-        simple_sampling = simple_sampling,
+        sampling_mode = sampling_mode,
         nonzero_prop = nonzero_prop,
-        fix_nonzero_prop = fix_nonzero_prop # if this is set to True, the data may contain padding
+        fix_nonzero_prop = fix_nonzero_prop,
+        hvg_inds = hvg_inds,
+        non_hvg_size = non_hvg_size # if this is set to True, the data may contain padding
     )
     return batch_padded, used_indices
 

--- a/perttf/utils/misc.py
+++ b/perttf/utils/misc.py
@@ -79,6 +79,7 @@ def init_plot_worker():
     import os
     import sys
     import warnings
+    warnings.filterwarnings('ignore', category=UserWarning)
     # Set environment in each worker
     conda_lib = os.path.join(sys.prefix, 'lib')
     os.environ['LD_LIBRARY_PATH'] = f"{conda_lib}:{os.environ.get('LD_LIBRARY_PATH', '')}"

--- a/perttf/utils/misc.py
+++ b/perttf/utils/misc.py
@@ -73,3 +73,22 @@ def unbin_matrix(
             unbinned_matrix[i, binned_row == bin_idx] = rep_value
 
     return unbinned_matrix
+
+def init_plot_worker():
+    """Initialize each worker process"""
+    import os
+    import sys
+    import warnings
+    # Set environment in each worker
+    conda_lib = os.path.join(sys.prefix, 'lib')
+    os.environ['LD_LIBRARY_PATH'] = f"{conda_lib}:{os.environ.get('LD_LIBRARY_PATH', '')}"
+    os.environ["OMP_NUM_THREADS"] = "1"
+    os.environ["MKL_NUM_THREADS"] = "1"
+    import matplotlib
+    matplotlib.use('Agg')
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        try: # supress that stupid scgpt warning for flash_attn
+            import scgpt
+        except Exception:
+            pass

--- a/perttf/utils/pert_data_loader.py
+++ b/perttf/utils/pert_data_loader.py
@@ -326,10 +326,10 @@ class PertBatchCollator:
     """
     A collate function for the DataLoader that tokenizes, pads, and masks batches on the fly.
     """
-    def __init__(self, vocab: object, gene_ids: np.ndarray, full_tokenize: bool = False, **config):
+    def __init__(self, vocab: object, gene_ids: np.ndarray, full_tokenize: bool = False, hvg_inds = None, **config):
         self.config = config
         self.vocab = vocab
-        self.gene_ids = gene_ids
+        self.gene_ids = gene_ids # vector of gene ids
         self.full_tokenize = full_tokenize
         self.include_zero_gene = config.get('include_zero_gene', True)
         self.append_cls = config.get('append_cls', True)
@@ -341,9 +341,10 @@ class PertBatchCollator:
         self.mask_ratio = config.get('mask_ratio', 0.15)
         self.mask_value = config.get('mask_value', -1)
         self.nonzero_prop = config.get('nonzero_prop', 0.7)
-        self.simple_sampling = config.get('simple_sampling', True)
+        self.sampling_mode = config.get('sampling_mode', 'simple')
         self.fix_nonzero_prop = config.get('fix_nonzero_prop', False)
-        
+        self.non_hvg_size = config.get('non_hvg_size', 1000)
+        self.hvg_inds = hvg_inds
 
     def __call__(self, batch: list) -> dict:
         """
@@ -367,15 +368,18 @@ class PertBatchCollator:
             expr_mat, self.gene_ids, max_len=max_seq_len,cls_token=self.cls_token,
             vocab=self.vocab, pad_token=self.pad_token, pad_value=self.pad_value,
             append_cls=self.append_cls, include_zero_gene=self.include_zero_gene, 
-            cls_value=self.cls_value, simple_sampling = self.simple_sampling,
-            fix_nonzero_prop=self.fix_nonzero_prop, nonzero_prop=self.nonzero_prop
+            cls_value=self.cls_value, sampling_mode = self.sampling_mode,
+            fix_nonzero_prop=self.fix_nonzero_prop, nonzero_prop=self.nonzero_prop,
+            hvg_inds = self.hvg_inds, non_hvg_size= self.non_hvg_size
         )
         tokenized_next, _ = tokenize_and_pad_batch(
             expr_mat_next, self.gene_ids, max_len=max_seq_len, cls_token=self.cls_token,
             vocab=self.vocab, pad_token=self.pad_token, pad_value=self.pad_value,
             append_cls=self.append_cls, include_zero_gene=self.include_zero_gene, 
-            sample_indices=gene_idx_list, cls_value=self.cls_value, simple_sampling = self.simple_sampling,
-            fix_nonzero_prop=self.fix_nonzero_prop, nonzero_prop=self.nonzero_prop
+            sample_indices=gene_idx_list, 
+            cls_value=self.cls_value, sampling_mode = self.sampling_mode,
+            fix_nonzero_prop=self.fix_nonzero_prop, nonzero_prop=self.nonzero_prop,
+            hvg_inds = self.hvg_inds, non_hvg_size= self.non_hvg_size
         )
         
         # 3. Apply random masking for this batch
@@ -466,12 +470,21 @@ class PertTFUniDataManager:
 
         self.set_genotype_index(genotype_to_index= genotype_to_index)
         self.set_celltype_index(celltype_to_index= celltype_to_index)
+
+        self.hvg_inds = None
+        if config.get('sampling_mode', 'simple') == 'hvg':
+            self.hvg_col = config.get('hvg_col', 'highly_variable')
+            assert self.hvg_col in adata.var.keys(), 'adata must have calculated HVGs or adata.var must have hvg_col'
+            n_hvg = self.adata.var[self.hvg_col].sum()
+            self.config.update({'max_seq_len': n_hvg+config.get('non_hvg_size', 1000)+config.get('append_cls', True)}, allow_val_change=True)
+            print(f'sampling_mode is hvg, using {n_hvg} genes for training')
+            self.hvg_inds = (np.where(self.adata.var[self.hvg_col])[0], np.where(~self.adata.var[self.hvg_col])[0])
         
         add_batch_info(self.adata)
         self.num_batch_types = len(self.adata.obs["batch_id"].unique())
         # The collators can be created once and reused
         ## first collator is the training collator, with a context window set in config
-        self.collator = PertBatchCollator(self.vocab, self.gene_ids, **config)
+        self.collator = PertBatchCollator(self.vocab, self.gene_ids, hvg_inds = self.hvg_inds, **config)
         ## full collator may be used for validation or inference 
         ## This may be very slow for full gene set, scaling is roughly 2x context length -> 3.6x time, 3-4x more memory
         self.full_token_collator = PertBatchCollator( self.vocab, self.gene_ids, full_tokenize=True, **config)

--- a/perttf/utils/plot.py
+++ b/perttf/utils/plot.py
@@ -72,14 +72,14 @@ def process_and_log_umaps(adata_t, config, epoch: int, eval_key: str, save_dir: 
             "pred_celltype", "genotype_next", "next_umap_celltype",
             "next_umap_genotype", "next_umap_genotype_next"
         ]
+        saved_images = {}
         for res_key, res_img_val in results.items():
             if res_key in save_image_types:
                 save_path = save_dir / f"{eval_key}_embeddings_{res_key}_e{epoch}.png"
                 res_img_val.savefig(save_path, dpi=300, bbox_inches='tight')
                 plt.close(res_img_val) # Close the figure to free memory
-                metrics_to_log[f"test/{eval_key}_{res_key}"] = wandb.Image(
-                    str(save_path), caption=f"{eval_key}_{res_key} epoch {epoch}"
-                )
+                saved_images[f"test/{eval_key}_{res_key}"] = str(save_path)
+                #wandb.Image(str(save_path), caption=f"{eval_key}_{res_key} epoch {epoch}")
         
         # Handle Loness score plotting
         if config.ps_weight > 0:
@@ -102,11 +102,16 @@ def process_and_log_umaps(adata_t, config, epoch: int, eval_key: str, save_dir: 
                     plt.close(fig_lonc_pred)
 
         # Log all collected metrics to wandb
-        if metrics_to_log:
-            wandb.log(metrics_to_log)
+        #if metrics_to_log:
+            #wandb.log(metrics_to_log)
 
-        print(f"[Process {os.getpid()}] Finished processing for epoch {epoch}, key '{eval_key}'.")
-
+        return {
+            'images': saved_images,
+            'metrics': metrics_to_log,
+            'eval_dict_key': eval_key,
+            'epoch': epoch
+        }
+        
         # added: write validation adata_t back to disk
         # adata_t.write_h5ad(save_dir / f'adata_last_validation_{eval_key}.h5ad')
 

--- a/perttf/utils/plot.py
+++ b/perttf/utils/plot.py
@@ -6,6 +6,110 @@ import anndata
 import os
 from pathlib import Path
 
+from scipy.stats import pearsonr
+import numpy as np
+import pandas as pd
+import seaborn as sns
+import matplotlib.pyplot as plt
+from sklearn.metrics import (
+    classification_report,
+    confusion_matrix,
+    roc_auc_score,
+    average_precision_score, # For AUPR
+)
+from sklearn.preprocessing import label_binarize
+
+def plot_confusion_matrix(y_true, y_pred, class_labels, title):
+    """Generates and plots a confusion matrix."""
+    cm = confusion_matrix(y_true, y_pred, labels=class_labels)
+    plt.figure(figsize=(12, 8))
+    sns.heatmap(
+        cm,
+        annot=True,
+        fmt="d", # Integer format
+        cmap="Blues",
+        xticklabels=class_labels,
+        yticklabels=class_labels,
+    )
+    plt.ylabel("Actual")
+    plt.xlabel("Predicted")
+    plt.title(title)
+    plt.show()
+
+def get_classification_metrics(
+    adata,
+    true_label_col: str,
+    true_label_col_id: str,
+    pred_label_col: str,
+    proba_obsm_key: str
+):
+    """
+    Calculates and displays comprehensive classification metrics for a multi-class task.
+
+    Args:
+        adata: Your AnnData object.
+        true_label_col: The column name in adata.obs for the ground truth labels.
+        pred_label_col: The column name in adata.obs for the predicted labels.
+        proba_obsm_key: The key in adata.obsm where the (n_obs, n_classes)
+                        prediction probabilities are stored.
+    """
+    df = adata.obs
+    y_true = df[true_label_col]
+    y_pred = df[pred_label_col]
+    y_true_id = df[true_label_col_id]
+    # Get the unique class labels in the correct order
+    class_labels = sorted(y_true.unique())
+    class_labels_id = sorted(y_true_id.unique().categories)
+    # 1. Classification Report (Precision, Recall, F1-Score)
+
+    # --- Metrics requiring probabilities ---
+    if proba_obsm_key in adata.obsm:
+        y_probas = adata.obsm[proba_obsm_key]
+        # Ensure y_probas columns align with class_labels.
+        # This is a common source of error. The example assumes the
+        # model's output probability columns are in the sorted order of class names.
+        
+        # Binarize the true labels for multi-class AUC calculations
+        y_true_binarized = label_binarize(y_true_id, classes=class_labels_id)
+
+        # 2. ROC-AUC Score (One-vs-Rest)
+        # We use a weighted average to account for class imbalance.
+        roc_auc = roc_auc_score(
+            y_true_binarized,
+            y_probas,
+            multi_class="ovr",
+            average="macro"
+        )
+
+
+        # 3. AUPR Score (Area Under Precision-Recall Curve)
+        aupr = average_precision_score(y_true_binarized, y_probas, average="macro")
+
+
+    else:
+        print(f"'{proba_obsm_key}' not found in adata.obsm. Skipping ROC-AUC and AUPR calculation.\n")
+
+    # 4. Confusion Matrix Plot
+    #plot_confusion_matrix(
+        #y_true,
+        #y_pred,
+        #class_labels=class_labels,
+        #title=f"Confusion Matrix for '{true_label_col}'"
+    #)
+    return roc_auc, aupr
+
+
+def expression_correlation(adata, expr_layer = 'next_expr', pred_layer = 'mvc_next_expr', zero_layer = None):
+    true_expr = adata.layers[expr_layer].toarray()
+    pred_expr = adata.obsm[pred_layer]
+    true_expr_mean = true_expr.mean(0)
+    pred_expr_zero = adata.obsm[zero_layer] if zero_layer is not None else 1
+    pred_expr = pred_expr * pred_expr_zero
+    pred_corr = np.mean([pearsonr(pred_expr[i,:], true_expr[i,:])[0] for i in range(true_expr.shape[0])])
+    mean_corr = np.mean([pearsonr(true_expr_mean, true_expr[i,:])[0] for i in range(true_expr.shape[0])])
+    return pred_corr, mean_corr
+
+
 def process_and_log_umaps(adata_t, config, epoch: int, eval_key: str, save_dir: Path, data_gen_ps_names: list = None):
     """
     Worker function to run UMAP, plotting, and logging in a separate process.
@@ -15,11 +119,33 @@ def process_and_log_umaps(adata_t, config, epoch: int, eval_key: str, save_dir: 
         
         # Load the AnnData object from the provided path
         #adata_t 
-
+        print(adata_t.obs['celltype_id'].unique())
         # This block is moved directly from your original `eval_testdata` function
         results = {}
         metrics_to_log = {"epoch": epoch}
-
+        if 'mvc_next_expr' in adata_t.obsm.keys():
+            print('start expression eval')
+            adata_wt = adata_t[adata_t.obs.genotype == 'WT',:]
+            mvc_pred = expression_correlation(adata_wt, expr_layer = 'next_expr', pred_layer = 'mvc_next_expr')
+            metrics_to_log[f"test/{eval_key}_pred_next_corr"] = mvc_pred[0]
+            metrics_to_log[f"test/{eval_key}_mean_expr_corr"] = mvc_pred[1]
+        print('start class eval')
+        celltype_auc, celltype_aupr = get_classification_metrics(adata_t,
+                                                                true_label_col="celltype",
+                                                                true_label_col_id="celltype_id",
+                                                                pred_label_col="predicted_celltype",
+                                                                proba_obsm_key="X_cls_pred_probs" )
+        genotype_auc, genotype_aupr = get_classification_metrics(adata_t,
+                                                                true_label_col="genotype",
+                                                                true_label_col_id="genotype_id",
+                                                                pred_label_col="predicted_genotype",
+                                                                proba_obsm_key="X_pert_pred_probs" )
+        
+        metrics_to_log[f"test/{eval_key}_celltype_auc"] = celltype_auc
+        metrics_to_log[f"test/{eval_key}_celltype_aupr"] = celltype_aupr 
+        metrics_to_log[f"test/{eval_key}_genotype_auc"] = genotype_auc
+        metrics_to_log[f"test/{eval_key}_genotype_aupr"] = genotype_aupr
+        print('start umap')
         if config.next_cell_pred_type == 'pert':
             sc.pp.neighbors(adata_t, use_rep="X_scGPT_next")
             sc.tl.umap(adata_t, min_dist=0.3)


### PR DESCRIPTION
# Minor Changes
- changed `simple_sampling` config to `sampling_mode`, now supports using hvgs by providing a `hvg_col` to config
- `non-hvg-size` determines how many non-hvgs are sampled for each cell (NOTE, in `hvg` mode, all HVGs are used for each cell training)
- track macro-AUPR macro-AUC and predicted perturbed expression during `pert` training using wandb

# Fixes
- fixed multiprocessing issues for UMAP due to OpenMP, more robust now but a bit slower