### PR TITLE
Feature-conditioned perturbation encoder for zero-shot conditions

### DIFF
--- a/perttf/model/hf.py
+++ b/perttf/model/hf.py
@@ -124,6 +124,12 @@ class HFPerturbationTFModel(PerturbationTFModel, PyTorchModelHubMixin):
             self.ps_names = kwargs.pop('ps_names')
             self._hub_mixin_config['n_ps'] = len(self.ps_names)
 
+        # Optional perturbation FEATURE matrix (n_pert, feat_dim). Like the other
+        # running params it is a tensor/array (not JSON-serializable), so it is kept
+        # out of the HF config and forwarded directly to the parent, which builds a
+        # FeaturePertEncoder when it is not None (enables zero-shot prediction).
+        self.pert_features = kwargs.pop('pert_features', None)
+
                 # fix up some old configurations and param names
         if kwargs.get('layer_size', False):
             self._hub_mixin_config['d_model'] = kwargs.pop('layer_size')
@@ -185,6 +191,7 @@ class HFPerturbationTFModel(PerturbationTFModel, PyTorchModelHubMixin):
             ps_decoder2_nlayer=ps_decoder2_nlayer,
             pert_pad_id=pert_pad_id,
             pert_dim=pert_dim,
+            pert_features=self.pert_features,
             # Note: We do NOT pass **kwargs here, so parent doesn't see extra params.
         )
 
@@ -230,7 +237,10 @@ class HFPerturbationTFModel(PerturbationTFModel, PyTorchModelHubMixin):
             'cell_type_to_index': getattr(self, 'cell_type_to_index', None),
             'genotype_to_index': getattr(self, 'genotype_to_index', None),
             'ps_names': getattr(self, 'ps_names', None),
-            'num_batch_labels': getattr(self, 'num_batch_labels', 1)
+            'num_batch_labels': getattr(self, 'num_batch_labels', 1),
+            # Needed at from_pretrained time to rebuild FeaturePertEncoder BEFORE
+            # weights load, otherwise pert_encoder.proj/features keys are dropped.
+            'pert_features': getattr(self, 'pert_features', None),
         }
         # Filter None values
         running_params_to_save = {k: v for k, v in running_params_to_save.items() if v is not None}
@@ -341,6 +351,14 @@ class HFPerturbationTFModel(PerturbationTFModel, PyTorchModelHubMixin):
             print(f'WARNING: ps column names provided by user, ps score prediction head may be different from pretrained model, this is okay for finetuning')
         elif 'ps_names' in running_params:
             config['ps_names'] = running_params['ps_names']
+
+        # Restore the perturbation feature matrix so the parent builds a
+        # FeaturePertEncoder before weights are loaded (zero-shot encoder).
+        if kwargs.get('pert_features', None) is not None:
+            config['pert_features'] = kwargs['pert_features']
+            print(f'WARNING: pert_features provided by user, perturbation encoder may be different from pretrained model, this is okay for finetuning')
+        elif running_params.get('pert_features', None) is not None:
+            config['pert_features'] = running_params['pert_features']
 
         # let user option to choose attention backend
         if 'use_fast_transformer' in kwargs:

--- a/perttf/model/modules.py
+++ b/perttf/model/modules.py
@@ -673,7 +673,63 @@ class PertLabelEncoder(nn.Module):
         x = self.enc_norm(x)
         return x
 
-    
+
+class FeaturePertEncoder(nn.Module):
+    """
+    Feature-conditioned perturbation encoder.
+
+    Drop-in replacement for ``PertLabelEncoder`` with an identical
+    ``forward(LongTensor idx) -> (batch, embedding_dim)`` interface, so the rest of
+    ``PerturbationTFModel`` needs no change. Instead of looking up an independently
+    learned row per genotype index (``nn.Embedding``), it maps a *fixed feature
+    vector* for each perturbation through a small trainable MLP. Because the
+    embedding is a smooth function of features (gene/drug identity), a perturbation
+    that was NEVER seen in training still receives a meaningful embedding from its
+    feature row -> this is what enables zero-shot (regime-A) prediction of novel
+    conditions, which the index-lookup encoder structurally cannot do.
+
+    Args:
+        pert_features: array-like, shape (n_pert, feat_dim). Row i is the feature
+            vector for the perturbation whose ``genotype_to_index`` value is i.
+            Held-out/novel conditions MUST be assigned an index + row here too.
+        embedding_dim: output embedding size (must match ``pert_dim`` / d_model use).
+        hidden_dim: MLP hidden width (defaults to embedding_dim).
+        padding_idx: optional index whose embedding is forced to zero (e.g. a pad
+            perturbation), mirroring nn.Embedding's padding_idx semantics.
+    """
+
+    def __init__(
+        self,
+        pert_features,
+        embedding_dim: int,
+        hidden_dim: Optional[int] = None,
+        padding_idx: Optional[int] = None,
+    ):
+        super().__init__()
+        feats = torch.as_tensor(pert_features, dtype=torch.float32)
+        if feats.dim() != 2:
+            raise ValueError(f"pert_features must be 2-D (n_pert, feat_dim), got {tuple(feats.shape)}")
+        # fixed (non-trained) feature table; moves with .to(device) and is saved in state_dict
+        self.register_buffer("features", feats)
+        feat_dim = feats.shape[1]
+        hidden_dim = embedding_dim if hidden_dim is None else hidden_dim
+        self.proj = nn.Sequential(
+            nn.Linear(feat_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, embedding_dim),
+        )
+        self.enc_norm = nn.LayerNorm(embedding_dim)
+        self.padding_idx = padding_idx
+
+    def forward(self, x: Tensor) -> Tensor:
+        feats = self.features[x]          # (batch, feat_dim) — gathers rows by index
+        emb = self.proj(feats)            # (batch, embedding_dim)
+        emb = self.enc_norm(emb)
+        if self.padding_idx is not None:
+            emb = emb.masked_fill((x == self.padding_idx).unsqueeze(-1), 0.0)
+        return emb
+
+
 class PertExpEncoder(nn.Module):
     """
     Concatenating gene expression embeddings (from transformers) with perturbation embeddings (from scGPT's PertEncoder)

--- a/perttf/model/pertTF.py
+++ b/perttf/model/pertTF.py
@@ -20,7 +20,8 @@ from .modules import (
     PerturbationDecoder,
     PSDecoder,
     Batch2LabelEncoder,
-    PertLabelEncoder
+    PertLabelEncoder,
+    FeaturePertEncoder
     )
 
 
@@ -34,13 +35,22 @@ class PerturbationTFModel(BaseModel):
         ps_decoder2_nlayer = kwargs.pop("ps_decoder2_nlayer",3) # additional parameter to specify ps_decoder2 nlayer
         self.pert_pad_id = kwargs.pop("pert_pad_id", None) # get the pert_pad_id
         self.pert_dim = kwargs.pop('pert_dim', None)
+        # optional perturbation FEATURE matrix (n_pert, feat_dim). When provided, the
+        # perturbation encoder maps each genotype index through its feature vector + an
+        # MLP instead of an independent lookup row, so novel (unseen-in-training)
+        # conditions get a meaningful embedding -> enables zero-shot (regime-A) prediction.
+        self.pert_features = kwargs.pop("pert_features", None)
         super().__init__(*args, **kwargs)
         # add perturbation encoder
         # variables are defined in super class
-        d_model = self.d_model 
+        d_model = self.d_model
         pert_dim = d_model if self.pert_dim is None else self.pert_dim
         #self.pert_encoder = nn.Embedding(3, d_model, padding_idx=pert_pad_id)
-        self.pert_encoder = PertLabelEncoder(n_pert, pert_dim, padding_idx=self.pert_pad_id)
+        if self.pert_features is not None:
+            self.pert_encoder = FeaturePertEncoder(
+                self.pert_features, pert_dim, padding_idx=self.pert_pad_id)
+        else:
+            self.pert_encoder = PertLabelEncoder(n_pert, pert_dim, padding_idx=self.pert_pad_id)
         self.pert_exp_encoder = PertExpEncoder(d_model, self.pert_dim) 
         # the following is the perturbation decoder
         #n_pert = kwargs.get("n_perturb", 1) 


### PR DESCRIPTION
## Motivation
`PertLabelEncoder` is an `nn.Embedding` indexed by a genotype index built only from **training** genotypes. A perturbation absent from training therefore has:
1. no index → `KeyError` in `genotype_to_index` lookups (`pert_data_loader.py:326/333`, `train_function.py:692`), and
2. even if assigned an index, only a random untrained row.

So the model structurally **cannot predict an unseen perturbation** (zero-shot / leave-one-condition-out).

## Change
- **`FeaturePertEncoder`** (`perttf/model/modules.py`): a drop-in replacement for `PertLabelEncoder` with the identical `forward(LongTensor idx) -> (B, embedding_dim)` interface. It holds a fixed per-perturbation feature matrix (registered buffer) + a trainable MLP `feat_dim -> embedding_dim`, so the embedding is a smooth function of perturbation **features** (e.g. gene/drug identity embeddings). A perturbation never seen in training still gets a meaningful embedding from its feature row → enables zero-shot prediction.
- **`pert_features` kwarg** in `PerturbationTFModel.__init__` (`perttf/model/pertTF.py`): when provided, uses `FeaturePertEncoder` instead of `PertLabelEncoder`.

## Backward compatibility
`pert_features` defaults to `None`, which preserves the existing index-lookup encoder **exactly** — no behavior change for current training/inference.

## Usage
```python
model = PerturbationTFModel(..., pert_features=feat_matrix)  # (n_pert, feat_dim), row i = features for genotype index i
```
Assign the held-out/novel condition an index + feature row (e.g. via a union `genotype_to_index`) so it can be embedded at inference.

## Validation
Unit-tested: held-out index → real non-zero embedding (no crash), `padding_idx` → zero embedding, CUDA buffer move, and interface parity with `PertLabelEncoder`. The optimizer is built from `model.parameters()` in `wrapper_train`, so the new MLP params are trained.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)